### PR TITLE
fix bug in `time-extend.js`

### DIFF
--- a/static/js/time-extend.js
+++ b/static/js/time-extend.js
@@ -6,8 +6,9 @@ add_local_tz = (selector) => {
     const t = $(this).text();
     const res = regex_time.exec(t);
     if (res) {
-      const start_time = moment.utc(`2020-11-16 ${res[1]}`);
-      const end_time = moment.utc(`2020-11-20 ${res[2]}`);
+      const dummy_date_str = "2020-11-16";
+      const start_time = moment.utc(`${dummy_date_str} ${res[1]}`);
+      const end_time = moment.utc(`${dummy_date_str} ${res[2]}`);
       const local_start = start_time.tz(guess_tz);
       const local_start_and_tz = start_time.format("HH:mm");
       const local_end = end_time.tz(guess_tz);


### PR DESCRIPTION
Fixes #108.

<img width="1144" alt="Screen Shot 2020-11-10 at 11 38 50 PM" src="https://user-images.githubusercontent.com/9957482/98783137-ebf5c900-23ad-11eb-88b9-75566cd4c913.png">
